### PR TITLE
Refactor batch_badge_creator

### DIFF
--- a/conference_badges.rb
+++ b/conference_badges.rb
@@ -8,7 +8,7 @@ end
 
 def batch_badge_creator(attendees)
   attendees.map do |attendee|
-    "Hello, my name is #{attendee}."
+    badge_maker(attendee)
   end
 end
 


### PR DESCRIPTION
Changed the batch_badge_creator method to call badge_maker method.
Reduces code re-use, and also means that all badges (whether made individually, or through the batch creator) will be identical.
